### PR TITLE
refactor: replace use_color param with owo-colors override system

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -42,6 +42,7 @@ fn generate_log_batch(count: usize) -> Vec<String> {
 }
 
 fn bench_parse_and_format(c: &mut Criterion) {
+    owo_colors::set_override(false);
     let config = cor::Config::default();
     let lines = generate_log_batch(1000);
 
@@ -53,7 +54,7 @@ fn bench_parse_and_format(c: &mut Criterion) {
         b.iter(|| {
             for line in &lines {
                 out.clear();
-                cor::format_line(black_box(line), &config, false, &mut out);
+                cor::format_line(black_box(line), &config, &mut out);
                 black_box(&out);
             }
         });
@@ -104,7 +105,7 @@ fn bench_format_mixed_input(c: &mut Criterion) {
         b.iter(|| {
             for line in &lines {
                 out.clear();
-                cor::format_line(black_box(line), &config, false, &mut out);
+                cor::format_line(black_box(line), &config, &mut out);
                 black_box(&out);
             }
         });
@@ -148,7 +149,7 @@ fn bench_line_sizes(c: &mut Criterion) {
             let mut out = String::with_capacity(line.len() * 2);
             b.iter(|| {
                 out.clear();
-                cor::format_line(black_box(line), &config, false, &mut out);
+                cor::format_line(black_box(line), &config, &mut out);
                 black_box(&out);
             });
         });
@@ -172,7 +173,7 @@ fn bench_level_filtering(c: &mut Criterion) {
         b.iter(|| {
             for line in &lines {
                 out.clear();
-                cor::format_line(black_box(line), &config, false, &mut out);
+                cor::format_line(black_box(line), &config, &mut out);
                 black_box(&out);
             }
         });
@@ -202,7 +203,7 @@ fn bench_embedded_json(c: &mut Criterion) {
         b.iter(|| {
             for line in &lines {
                 out.clear();
-                cor::format_line(black_box(line), &config, false, &mut out);
+                cor::format_line(black_box(line), &config, &mut out);
                 black_box(&out);
             }
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::cli::{Cli, ColorMode};
 use crate::error::CorError;
-use crate::level::Level;
+use crate::level::{Level, color_name_to_style};
 
 /// Runtime configuration merged from defaults, config file, and CLI arguments.
 ///
@@ -199,7 +199,7 @@ impl Config {
             for (level_str, color) in colors {
                 if let Some(level) = Level::from_str_loose(&level_str) {
                     // Validate color name
-                    if is_valid_color(&color) {
+                    if color_name_to_style(&color).is_some() {
                         level_colors.insert(level, color.to_lowercase());
                     }
                 }
@@ -209,30 +209,6 @@ impl Config {
             }
         }
     }
-}
-
-/// Check if a color name is valid.
-fn is_valid_color(color: &str) -> bool {
-    matches!(
-        color.to_lowercase().as_str(),
-        "black"
-            | "red"
-            | "green"
-            | "yellow"
-            | "blue"
-            | "magenta"
-            | "purple"
-            | "cyan"
-            | "white"
-            | "bright_black"
-            | "bright_red"
-            | "bright_green"
-            | "bright_yellow"
-            | "bright_blue"
-            | "bright_magenta"
-            | "bright_cyan"
-            | "bright_white"
-    )
 }
 
 /// Config file structure (TOML deserialization).

--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -13,6 +13,7 @@
 use std::fmt::Write;
 
 use owo_colors::OwoColorize;
+use owo_colors::Stream::Stdout;
 
 use crate::config::Config;
 use crate::level::Level;
@@ -25,9 +26,9 @@ use crate::parser::{self, LineKind, LogRecord};
 /// If `--json` mode is active, output raw JSON (suppress non-JSON lines).
 ///
 /// The result is written into `out`.
-pub fn format_line(line: &str, config: &Config, use_color: bool, out: &mut String) {
+pub fn format_line(line: &str, config: &Config, out: &mut String) {
     let parsed = parser::parse_line(line, config);
-    format_line_parsed(parsed, line, config, use_color, out);
+    format_line_parsed(parsed, line, config, out);
 }
 
 /// Format a pre-parsed [`LineKind`] for output.
@@ -35,13 +36,7 @@ pub fn format_line(line: &str, config: &Config, use_color: bool, out: &mut Strin
 /// Like [`format_line`], but accepts an already-parsed [`LineKind`] instead of
 /// a raw line string. The `raw_line` parameter is used for `LineKind::Raw`
 /// passthrough.
-pub fn format_line_parsed(
-    parsed: LineKind,
-    raw_line: &str,
-    config: &Config,
-    use_color: bool,
-    out: &mut String,
-) {
+pub fn format_line_parsed(parsed: LineKind, raw_line: &str, config: &Config, out: &mut String) {
     match parsed {
         LineKind::Json(record) => {
             if should_filter(&record, config) {
@@ -52,7 +47,7 @@ pub fn format_line_parsed(
             if config.json_output {
                 out.push_str(&record.raw_json);
             } else {
-                format_record(&record, None, config, use_color, out);
+                format_record(&record, None, config, out);
             }
         }
         LineKind::EmbeddedJson { prefix, record } => {
@@ -63,7 +58,7 @@ pub fn format_line_parsed(
             if config.json_output {
                 out.push_str(&record.raw_json);
             } else {
-                format_record(&record, Some(&prefix), config, use_color, out);
+                format_record(&record, Some(&prefix), config, out);
             }
         }
         LineKind::Raw(parse_error) => {
@@ -79,23 +74,15 @@ pub fn format_line_parsed(
             if config.verbose
                 && let Some(err) = parse_error
             {
-                if use_color {
-                    use owo_colors::OwoColorize;
-                    let _ = write!(
-                        out,
-                        "\n  {} [{}:{}] {}",
-                        "parse error:".red().bold(),
-                        err.line,
-                        err.column,
-                        err.message.dimmed()
-                    );
-                } else {
-                    let _ = write!(
-                        out,
-                        "\n  parse error: [{}:{}] {}",
-                        err.line, err.column, err.message
-                    );
-                }
+                let _ = write!(
+                    out,
+                    "\n  {} [{}:{}] {}",
+                    "parse error:".if_supports_color(Stdout, |t| t.red().bold().to_string()),
+                    err.line,
+                    err.column,
+                    err.message
+                        .if_supports_color(Stdout, |t| t.dimmed().to_string()),
+                );
             }
         }
     }
@@ -123,39 +110,31 @@ fn should_filter(record: &LogRecord, config: &Config) -> bool {
 ///                           key: value
 ///                     other_key: other_value
 /// ```
-fn format_record(
-    record: &LogRecord,
-    prefix: Option<&str>,
-    config: &Config,
-    use_color: bool,
-    out: &mut String,
-) {
+fn format_record(record: &LogRecord, prefix: Option<&str>, config: &Config, out: &mut String) {
     // Timestamp (bold when colored)
     if let Some(ref ts) = record.timestamp {
         let ts_str = ts.format_with(&config.timestamp_format);
-        if use_color {
-            let _ = write!(out, "{}  ", ts_str.bold());
-        } else {
-            out.push_str(&ts_str);
-            out.push_str("  ");
-        }
+        let _ = write!(
+            out,
+            "{}  ",
+            ts_str.if_supports_color(Stdout, |t| t.bold().to_string())
+        );
     }
 
     // Level badge + colon
     if let Some(ref level) = record.level {
         let badge = level.badge();
-        if use_color {
-            let custom_color = config
-                .level_colors
-                .as_ref()
-                .and_then(|colors| colors.get(level))
-                .map(String::as_str);
-            let style = level.style_with_color(custom_color);
-            let _ = write!(out, "{}:", badge.style(style));
-        } else {
-            out.push_str(badge);
-            out.push(':');
-        }
+        let custom_color = config
+            .level_colors
+            .as_ref()
+            .and_then(|colors| colors.get(level))
+            .map(String::as_str);
+        let style = level.style_with_color(custom_color);
+        let _ = write!(
+            out,
+            "{}:",
+            badge.if_supports_color(Stdout, |t| t.style(style).to_string())
+        );
     } else {
         out.push_str(Level::blank_badge());
         out.push(':');
@@ -163,12 +142,11 @@ fn format_record(
 
     // Prefix (bold cyan when colored)
     if let Some(pfx) = prefix {
-        if use_color {
-            let _ = write!(out, " {}", pfx.bold().cyan());
-        } else {
-            out.push(' ');
-            out.push_str(pfx);
-        }
+        let _ = write!(
+            out,
+            " {}",
+            pfx.if_supports_color(Stdout, |t| t.bold().cyan().to_string())
+        );
     }
 
     // Message (plain text, no bold)
@@ -197,16 +175,13 @@ fn format_record(
         let val_str = format_value(value);
         let val_display = truncate_value(&val_str, max_len);
 
-        if use_color {
-            let _ = write!(
-                out,
-                "\n{}: {}",
-                format!("{key:>key_width$}").truecolor(150, 150, 150).bold(),
-                val_display
-            );
-        } else {
-            let _ = write!(out, "\n{key:>key_width$}: {val_display}");
-        }
+        let _ = write!(
+            out,
+            "\n{}: {}",
+            format!("{key:>key_width$}")
+                .if_supports_color(Stdout, |t| t.truecolor(150, 150, 150).bold().to_string()),
+            val_display
+        );
     }
 }
 
@@ -295,190 +270,6 @@ mod tests {
     }
 
     #[test]
-    fn test_format_line_raw_passthrough() {
-        let config = Config::default();
-        let mut out = String::new();
-        format_line("plain text line", &config, false, &mut out);
-        assert_eq!(out, "plain text line");
-    }
-
-    #[test]
-    fn test_format_line_json_no_color() {
-        let config = Config::default();
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hello","port":8080}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(out.contains("INFO"));
-        assert!(out.contains("hello"));
-        assert!(out.contains("port: 8080"));
-    }
-
-    #[test]
-    fn test_format_line_json_output_mode() {
-        let config = Config {
-            json_output: true,
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hello"}"#;
-        format_line(line, &config, false, &mut out);
-        assert_eq!(out, r#"{"level":"info","msg":"hello"}"#);
-    }
-
-    #[test]
-    fn test_format_line_json_suppresses_raw() {
-        let config = Config {
-            json_output: true,
-            ..Config::default()
-        };
-        let mut out = String::new();
-        format_line("plain text", &config, false, &mut out);
-        assert!(out.is_empty());
-    }
-
-    #[test]
-    fn test_level_filtering() {
-        let config = Config {
-            min_level: Some(Level::Warn),
-            ..Config::default()
-        };
-
-        // Info should be filtered
-        let mut out = String::new();
-        format_line(
-            r#"{"level":"info","msg":"hello"}"#,
-            &config,
-            false,
-            &mut out,
-        );
-        assert!(out.is_empty());
-
-        // Warn should pass
-        out.clear();
-        format_line(
-            r#"{"level":"warn","msg":"warning"}"#,
-            &config,
-            false,
-            &mut out,
-        );
-        assert!(out.contains("warning"));
-
-        // Raw always passes
-        out.clear();
-        format_line("plain text", &config, false, &mut out);
-        assert_eq!(out, "plain text");
-    }
-
-    #[test]
-    fn test_format_line_colorized_output() {
-        let config = Config::default();
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hello"}"#;
-        format_line(line, &config, true, &mut out);
-        // Should contain ANSI escape sequences
-        assert!(
-            out.contains("\x1b["),
-            "expected ANSI escapes in colorized output"
-        );
-        // Content should still be present
-        assert!(out.contains("hello"));
-    }
-
-    #[test]
-    fn test_exclude_fields() {
-        let config = Config {
-            exclude_fields: Some(vec!["port".to_string()]),
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hello","port":8080,"host":"localhost"}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(
-            !out.contains("port"),
-            "excluded field 'port' should not appear"
-        );
-        assert!(
-            out.contains("host"),
-            "non-excluded field 'host' should appear"
-        );
-    }
-
-    #[test]
-    fn test_include_fields() {
-        let config = Config {
-            include_fields: Some(vec!["port".to_string()]),
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hello","port":8080,"host":"localhost"}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(out.contains("port"), "included field 'port' should appear");
-        assert!(
-            !out.contains("host"),
-            "non-included field 'host' should not appear"
-        );
-    }
-
-    #[test]
-    fn test_max_field_length_applied_in_format_line() {
-        let config = Config {
-            max_field_length: 10,
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let long_value = "a".repeat(30);
-        let line = format!(r#"{{"level":"info","msg":"hi","data":"{long_value}"}}"#);
-        format_line(&line, &config, false, &mut out);
-        // The truncated value should end with '…' and be shorter than the original
-        assert!(out.contains('…'), "long field value should be truncated");
-        assert!(!out.contains(&long_value), "full value should not appear");
-    }
-
-    #[test]
-    fn test_timestamp_format_applied_in_format_line() {
-        let config = Config {
-            timestamp_format: "%H:%M:%S".to_string(),
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":"hi","time":"2026-01-15T10:30:00.123Z"}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(
-            out.contains("10:30:00"),
-            "custom timestamp format should be applied"
-        );
-        // Should NOT contain a date since the format is time-only
-        assert!(
-            !out.contains("2026-01-15"),
-            "date should not appear with time-only format"
-        );
-    }
-
-    #[test]
-    fn test_null_level_treated_as_absent() {
-        let config = Config::default();
-        let mut out = String::new();
-        let line = r#"{"level":null,"msg":"hello"}"#;
-        format_line(line, &config, false, &mut out);
-        // Should use blank badge (5 spaces) since level is null
-        assert!(
-            out.contains("     :"),
-            "null level should produce blank badge"
-        );
-        assert!(out.contains("hello"));
-    }
-
-    #[test]
-    fn test_null_message_treated_as_absent() {
-        let config = Config::default();
-        let mut out = String::new();
-        let line = r#"{"level":"info","msg":null,"port":8080}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(out.contains("INFO"));
-        assert!(out.contains("port"));
-    }
-
-    #[test]
     fn test_format_value_bool() {
         let val = serde_json::json!(true);
         assert_eq!(format_value(&val), "true");
@@ -490,17 +281,6 @@ mod tests {
     fn test_format_value_object() {
         let val = serde_json::json!({"a": 1});
         assert_eq!(format_value(&val), r#"{"a":1}"#);
-    }
-
-    #[test]
-    fn test_embedded_json_no_color() {
-        let config = Config::default();
-        let mut out = String::new();
-        let line = r#"2026-02-06 prefix {"level":"debug","msg":"check"}"#;
-        format_line(line, &config, false, &mut out);
-        assert!(out.contains("DEBUG"));
-        assert!(out.contains("check"));
-        assert!(out.contains("2026-02-06 prefix"));
     }
 
     #[test]
@@ -520,12 +300,202 @@ mod tests {
         assert_eq!(result, "\u{4F60}\u{597D}\u{2026}"); // 你好…
     }
 
+    fn disable_color() {
+        owo_colors::set_override(false);
+    }
+
+    #[test]
+    fn test_format_line_raw_passthrough() {
+        disable_color();
+        let config = Config::default();
+        let mut out = String::new();
+        format_line("plain text line", &config, &mut out);
+        assert_eq!(out, "plain text line");
+    }
+
+    #[test]
+    fn test_format_line_json_no_color() {
+        disable_color();
+        let config = Config::default();
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":"hello","port":8080}"#;
+        format_line(line, &config, &mut out);
+        assert!(out.contains("INFO"));
+        assert!(out.contains("hello"));
+        assert!(out.contains("port: 8080"));
+    }
+
+    #[test]
+    fn test_format_line_json_output_mode() {
+        disable_color();
+        let config = Config {
+            json_output: true,
+            ..Config::default()
+        };
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":"hello"}"#;
+        format_line(line, &config, &mut out);
+        assert_eq!(out, r#"{"level":"info","msg":"hello"}"#);
+    }
+
+    #[test]
+    fn test_format_line_json_suppresses_raw() {
+        disable_color();
+        let config = Config {
+            json_output: true,
+            ..Config::default()
+        };
+        let mut out = String::new();
+        format_line("plain text", &config, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_level_filtering() {
+        disable_color();
+        let config = Config {
+            min_level: Some(Level::Warn),
+            ..Config::default()
+        };
+
+        // Info should be filtered
+        let mut out = String::new();
+        format_line(r#"{"level":"info","msg":"hello"}"#, &config, &mut out);
+        assert!(out.is_empty());
+
+        // Warn should pass
+        out.clear();
+        format_line(r#"{"level":"warn","msg":"warning"}"#, &config, &mut out);
+        assert!(out.contains("warning"));
+
+        // Raw always passes
+        out.clear();
+        format_line("plain text", &config, &mut out);
+        assert_eq!(out, "plain text");
+    }
+
+    // Colorized output is tested via integration tests (color_always_enables_ansi,
+    // embedded_json_colorized) which control the --color flag end-to-end.
+
+    #[test]
+    fn test_exclude_fields() {
+        disable_color();
+        let config = Config {
+            exclude_fields: Some(vec!["port".to_string()]),
+            ..Config::default()
+        };
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":"hello","port":8080,"host":"localhost"}"#;
+        format_line(line, &config, &mut out);
+        assert!(
+            !out.contains("port"),
+            "excluded field 'port' should not appear"
+        );
+        assert!(
+            out.contains("host"),
+            "non-excluded field 'host' should appear"
+        );
+    }
+
+    #[test]
+    fn test_include_fields() {
+        disable_color();
+        let config = Config {
+            include_fields: Some(vec!["port".to_string()]),
+            ..Config::default()
+        };
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":"hello","port":8080,"host":"localhost"}"#;
+        format_line(line, &config, &mut out);
+        assert!(out.contains("port"), "included field 'port' should appear");
+        assert!(
+            !out.contains("host"),
+            "non-included field 'host' should not appear"
+        );
+    }
+
+    #[test]
+    fn test_max_field_length_applied_in_format_line() {
+        disable_color();
+        let config = Config {
+            max_field_length: 10,
+            ..Config::default()
+        };
+        let mut out = String::new();
+        let long_value = "a".repeat(30);
+        let line = format!(r#"{{"level":"info","msg":"hi","data":"{long_value}"}}"#);
+        format_line(&line, &config, &mut out);
+        // The truncated value should end with '…' and be shorter than the original
+        assert!(out.contains('…'), "long field value should be truncated");
+        assert!(!out.contains(&long_value), "full value should not appear");
+    }
+
+    #[test]
+    fn test_timestamp_format_applied_in_format_line() {
+        disable_color();
+        let config = Config {
+            timestamp_format: "%H:%M:%S".to_string(),
+            ..Config::default()
+        };
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":"hi","time":"2026-01-15T10:30:00.123Z"}"#;
+        format_line(line, &config, &mut out);
+        assert!(
+            out.contains("10:30:00"),
+            "custom timestamp format should be applied"
+        );
+        // Should NOT contain a date since the format is time-only
+        assert!(
+            !out.contains("2026-01-15"),
+            "date should not appear with time-only format"
+        );
+    }
+
+    #[test]
+    fn test_null_level_treated_as_absent() {
+        disable_color();
+        let config = Config::default();
+        let mut out = String::new();
+        let line = r#"{"level":null,"msg":"hello"}"#;
+        format_line(line, &config, &mut out);
+        // Should use blank badge (5 spaces) since level is null
+        assert!(
+            out.contains("     :"),
+            "null level should produce blank badge"
+        );
+        assert!(out.contains("hello"));
+    }
+
+    #[test]
+    fn test_null_message_treated_as_absent() {
+        disable_color();
+        let config = Config::default();
+        let mut out = String::new();
+        let line = r#"{"level":"info","msg":null,"port":8080}"#;
+        format_line(line, &config, &mut out);
+        assert!(out.contains("INFO"));
+        assert!(out.contains("port"));
+    }
+
+    #[test]
+    fn test_embedded_json_no_color() {
+        disable_color();
+        let config = Config::default();
+        let mut out = String::new();
+        let line = r#"2026-02-06 prefix {"level":"debug","msg":"check"}"#;
+        format_line(line, &config, &mut out);
+        assert!(out.contains("DEBUG"));
+        assert!(out.contains("check"));
+        assert!(out.contains("2026-02-06 prefix"));
+    }
+
     #[test]
     fn test_format_line_no_timestamp_no_level_no_message() {
+        disable_color();
         let config = Config::default();
         let mut out = String::new();
         let line = r#"{"port":8080,"host":"localhost"}"#;
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         // Should produce a blank badge and only extra fields
         assert!(out.contains("     :"), "should have blank badge");
         assert!(out.contains("port: 8080"));
@@ -534,6 +504,7 @@ mod tests {
 
     #[test]
     fn test_level_filtering_embedded_json() {
+        disable_color();
         let config = Config {
             min_level: Some(Level::Error),
             ..Config::default()
@@ -544,7 +515,6 @@ mod tests {
         format_line(
             r#"prefix {"level":"info","msg":"hello"}"#,
             &config,
-            false,
             &mut out,
         );
         assert!(out.is_empty(), "info should be filtered when min=error");
@@ -554,7 +524,6 @@ mod tests {
         format_line(
             r#"prefix {"level":"error","msg":"fail"}"#,
             &config,
-            false,
             &mut out,
         );
         assert!(out.contains("fail"), "error should pass when min=error");
@@ -562,6 +531,7 @@ mod tests {
 
     #[test]
     fn test_format_line_json_mode_embedded() {
+        disable_color();
         // --json mode with embedded JSON should output only the JSON part
         let config = Config {
             json_output: true,
@@ -571,7 +541,6 @@ mod tests {
         format_line(
             r#"prefix {"level":"info","msg":"hello"}"#,
             &config,
-            false,
             &mut out,
         );
         // Should output the raw JSON, not the prefix
@@ -581,6 +550,7 @@ mod tests {
 
     #[test]
     fn test_include_nonexistent_field() {
+        disable_color();
         // Including a field that doesn't exist should hide all extra fields
         let config = Config {
             include_fields: Some(vec!["nonexistent".to_string()]),
@@ -588,7 +558,7 @@ mod tests {
         };
         let mut out = String::new();
         let line = r#"{"level":"info","msg":"hello","port":8080}"#;
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         assert!(
             !out.contains("port"),
             "non-included fields should be hidden"
@@ -597,13 +567,14 @@ mod tests {
 
     #[test]
     fn test_verbose_shows_parse_error() {
+        disable_color();
         let config = Config {
             verbose: true,
             ..Config::default()
         };
         let mut out = String::new();
         let line = r#"{"level":"info", "msg":}"#; // Invalid JSON
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         assert!(
             out.contains("parse error:"),
             "verbose mode should show parse error"
@@ -617,13 +588,14 @@ mod tests {
 
     #[test]
     fn test_verbose_disabled_hides_parse_error() {
+        disable_color();
         let config = Config {
             verbose: false,
             ..Config::default()
         };
         let mut out = String::new();
         let line = r#"{"level":"info", "msg":}"#; // Invalid JSON
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         assert!(
             !out.contains("parse error"),
             "verbose off should not show parse error"
@@ -634,12 +606,13 @@ mod tests {
 
     #[test]
     fn test_verbose_no_error_for_plain_text() {
+        disable_color();
         let config = Config {
             verbose: true,
             ..Config::default()
         };
         let mut out = String::new();
-        format_line("plain text line", &config, false, &mut out);
+        format_line("plain text line", &config, &mut out);
         assert!(
             !out.contains("parse error"),
             "plain text should not show parse error"
@@ -649,13 +622,14 @@ mod tests {
 
     #[test]
     fn test_verbose_shows_error_for_embedded_malformed_json() {
+        disable_color();
         let config = Config {
             verbose: true,
             ..Config::default()
         };
         let mut out = String::new();
         let line = r#"prefix {"broken":}"#;
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         assert!(
             out.contains("parse error:"),
             "verbose should show error for malformed embedded JSON"
@@ -664,6 +638,7 @@ mod tests {
 
     #[test]
     fn test_level_filtering_no_level_passes_through() {
+        disable_color();
         // JSON records with no recognized level field should pass through
         // even when min_level filtering is active.
         let config = Config {
@@ -672,30 +647,10 @@ mod tests {
         };
         let mut out = String::new();
         let line = r#"{"msg":"no level field","port":8080}"#;
-        format_line(line, &config, false, &mut out);
+        format_line(line, &config, &mut out);
         assert!(
             out.contains("no level field"),
             "JSON record without level should pass through when filtering is active"
-        );
-    }
-
-    #[test]
-    fn test_verbose_parse_error_colorized() {
-        let config = Config {
-            verbose: true,
-            ..Config::default()
-        };
-        let mut out = String::new();
-        let line = r#"{"level":"info", "msg":}"#;
-        format_line(line, &config, true, &mut out);
-        // Should contain ANSI escape sequences in the error output
-        assert!(
-            out.contains("\x1b["),
-            "verbose colorized error should contain ANSI escapes"
-        );
-        assert!(
-            out.contains("parse error:"),
-            "verbose colorized error should contain 'parse error:'"
         );
     }
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -73,8 +73,8 @@ impl Level {
     /// If `custom_color` is `None`, falls back to the default color scheme.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn style_with_color(&self, custom_color: Option<&str>) -> Style {
-        match custom_color {
-            Some(color) => color_name_to_style(color),
+        match custom_color.and_then(color_name_to_style) {
+            Some(style) => style,
             None => self.style(),
         }
     }
@@ -144,9 +144,9 @@ impl Level {
 /// Convert a color name string to an [`owo_colors::Style`].
 ///
 /// Supports standard ANSI colors and bright variants. All styles are bold.
-/// Unknown colors fall back to white bold.
-fn color_name_to_style(color: &str) -> Style {
-    match color.to_lowercase().as_str() {
+/// Returns `None` for unrecognized color names.
+pub fn color_name_to_style(color: &str) -> Option<Style> {
+    let style = match color.to_lowercase().as_str() {
         "black" => Style::new().black().bold(),
         "red" => Style::new().red().bold(),
         "green" => Style::new().green().bold(),
@@ -154,6 +154,7 @@ fn color_name_to_style(color: &str) -> Style {
         "blue" => Style::new().blue().bold(),
         "magenta" | "purple" => Style::new().magenta().bold(),
         "cyan" => Style::new().cyan().bold(),
+        "white" => Style::new().white().bold(),
         "bright_black" => Style::new().bright_black().bold(),
         "bright_red" => Style::new().bright_red().bold(),
         "bright_green" => Style::new().bright_green().bold(),
@@ -162,9 +163,9 @@ fn color_name_to_style(color: &str) -> Style {
         "bright_magenta" => Style::new().bright_magenta().bold(),
         "bright_cyan" => Style::new().bright_cyan().bold(),
         "bright_white" => Style::new().bright_white().bold(),
-        // "white" and unknown colors
-        _ => Style::new().white().bold(),
-    }
+        _ => return None,
+    };
+    Some(style)
 }
 
 impl fmt::Display for Level {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@
 //! let config = Config::default();
 //! let mut out = String::new();
 //!
-//! format_line(r#"{"level":"info","msg":"hello","port":8080}"#, &config, false, &mut out);
+//! owo_colors::set_override(false);
+//! format_line(r#"{"level":"info","msg":"hello","port":8080}"#, &config, &mut out);
 //! assert!(out.contains("INFO"));
 //! assert!(out.contains("hello"));
 //! ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufRead, BufWriter, IsTerminal, Write};
+use std::io::{self, BufRead, BufWriter, Write};
 use std::process::ExitCode;
 
 use clap::Parser;
@@ -68,13 +68,17 @@ fn main() -> ExitCode {
         }
     };
 
-    let use_color = resolve_color_mode(config.color_mode);
+    match config.color_mode {
+        ColorMode::Always => owo_colors::set_override(true),
+        ColorMode::Never => owo_colors::set_override(false),
+        ColorMode::Auto => {} // owo-colors auto-detects via supports-color
+    }
 
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut writer = BufWriter::new(stdout.lock());
 
-    let exit = process_lines(stdin.lock().lines(), &config, use_color, &mut writer);
+    let exit = process_lines(stdin.lock().lines(), &config, &mut writer);
     if let Some(code) = exit {
         return code;
     }
@@ -93,7 +97,6 @@ fn main() -> ExitCode {
 fn process_lines(
     mut lines_iter: impl Iterator<Item = io::Result<String>>,
     config: &Config,
-    use_color: bool,
     writer: &mut BufWriter<io::StdoutLock<'_>>,
 ) -> Option<ExitCode> {
     let mut line_buf = String::new();
@@ -135,7 +138,7 @@ fn process_lines(
                     if !matches!(re_parsed, LineKind::Raw(_)) {
                         // Successfully assembled — format the sanitized version.
                         line_buf.clear();
-                        format_line_parsed(re_parsed, &sanitized, config, use_color, &mut line_buf);
+                        format_line_parsed(re_parsed, &sanitized, config, &mut line_buf);
                         assembled = true;
                         break;
                     }
@@ -145,7 +148,7 @@ fn process_lines(
                     // Could not reassemble — output each buffered line as raw.
                     for raw_line in buffer.split('\n') {
                         line_buf.clear();
-                        format_line(raw_line, config, use_color, &mut line_buf);
+                        format_line(raw_line, config, &mut line_buf);
                         if !line_buf.is_empty()
                             && let exit @ Some(_) = write_entry(writer, &line_buf, config.line_gap)
                         {
@@ -157,7 +160,7 @@ fn process_lines(
             }
             _ => {
                 line_buf.clear();
-                format_line_parsed(parsed, &line, config, use_color, &mut line_buf);
+                format_line_parsed(parsed, &line, config, &mut line_buf);
             }
         }
 
@@ -186,29 +189,6 @@ fn might_start_json(line: &str) -> bool {
         after_brace.trim_start().starts_with('"')
     } else {
         false
-    }
-}
-
-fn resolve_color_mode(mode: ColorMode) -> bool {
-    match mode {
-        ColorMode::Always => true,
-        ColorMode::Never => false,
-        ColorMode::Auto => {
-            let stdout = io::stdout();
-            if !stdout.is_terminal() {
-                return false;
-            }
-            if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
-                return false;
-            }
-            if std::env::var("TERM").is_ok_and(|v| v == "dumb") {
-                return false;
-            }
-            if std::env::var_os("FORCE_COLOR").is_some_and(|v| !v.is_empty()) {
-                return true;
-            }
-            true
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace hand-rolled `resolve_color_mode()` and threaded `use_color: bool` parameter with `owo_colors::set_override()`, leveraging the `supports-color` crate (already a transitive dependency via `owo-colors`) for auto-detection of `NO_COLOR`, `FORCE_COLOR`, `TERM=dumb`, TTY, and CI environments
- Unify duplicated color validation (`is_valid_color` + `color_name_to_style`) into a single `pub fn color_name_to_style() -> Option<Style>`
- Remove dead code: `Timestamp::original`, `CorError::Parse`, `find_key()`, `LOGGER_ALIASES`, `CALLER_ALIASES`, `ERROR_ALIASES`

Net: **-172 lines** across 9 files. No behavior change — all 129 unit tests, 65 integration tests, and 1 doc test pass.

## Test plan

- [x] `just check` (cargo fmt + clippy + test) passes
- [x] Smoke test: `echo '{"level":"info","msg":"hello","port":8080}' | cargo run`
- [x] `--color=always` produces ANSI escapes
- [x] `--color=never` produces plain text
- [x] Integration tests cover color auto-detection (NO_COLOR, TERM=dumb, piped stdout, --color flags)