### PR TITLE
chore(tests): replace deprecated assert_cmd::Command::cargo_bin with macro

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -10,9 +10,8 @@ mod multiline;
 use assert_cmd::Command;
 
 /// Shared helper: build a `cor` command with config isolation.
-#[allow(deprecated)]
 pub fn cor() -> Command {
-    let mut cmd = Command::cargo_bin("cor").unwrap();
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("cor"));
     cmd.env("XDG_CONFIG_HOME", "/tmp/cor-test-no-config");
     cmd
 }


### PR DESCRIPTION
## Summary

`assert_cmd::Command::cargo_bin` is deprecated because it cannot discover
binaries when a custom cargo `build-dir` is configured. Replace with the
`cargo_bin!` macro, which resolves the path at compile time via the
`CARGO_BIN_EXE_<name>` environment variable Cargo sets for integration
tests.

Drops the `#[allow(deprecated)]` opt-out.

No behavior change.

## Test plan

- [x] `just check` passes (fmt + clippy + 100 integration tests + 153 unit tests + 1 doctest)
- [x] No `#[allow(deprecated)]` left in `tests/integration/mod.rs`